### PR TITLE
feat: add general support for isBinary for all backends

### DIFF
--- a/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
@@ -83,9 +83,10 @@ spec:
                     description: Property to extract if secret in backend is a JSON object
                   isBinary:
                     description: >-
-                      You must set this to true if configuring an item for a binary file stored in Azure KeyVault.
-                      Azure automatically base64 encodes binary files and setting this to true ensures External Secrets
-                      does not base64 encode the base64 encoded binary files.
+                      Whether the backend secret shall be treated as binary data
+                      represented by a base64-encoded string. You must set this to true
+                      for any base64-encoded binary data in the backend - to ensure it
+                      is not encoded in base64 again. Default is false.
                     type: boolean
                 required:
                   - name

--- a/examples/hello-service-external-secret-gcp.yml
+++ b/examples/hello-service-external-secret-gcp.yml
@@ -15,5 +15,5 @@ spec:
       property: value
       # Version of the secret (default: 'latest')
       version: 1
-      # If the secret is encoded in base64 then decodes it (default: false)
+      # If the secret is already encoded in base64, then sends it unchanged (default: false)
       isBinary: false

--- a/examples/hello-service-external-secret-vault.yml
+++ b/examples/hello-service-external-secret-vault.yml
@@ -11,3 +11,7 @@ spec:
     - name: password
       key: secret/data/hello-service/password
       property: password
+    - name: cert.p12
+      key: secret/data/hello-service/certificates
+      property: cert.p12
+      isBinary: true # defaults to false

--- a/lib/backends/azure-keyvault-backend.js
+++ b/lib/backends/azure-keyvault-backend.js
@@ -26,18 +26,13 @@ class AzureKeyVaultBackend extends KVBackend {
    * Get secret property value from Azure Key Vault.
    * @param {string} key - Key used to store secret property value in Azure Key Vault.
    * @param {string} specOptions.keyVaultName - Name of the azure key vault
-   * @param {string} keyOptions.isBinary - Does the secret contain a binary? Set to "true" to handle as binary. Does not work with "property"
    * @returns {Promise} Promise object representing secret property value.
    */
 
-  async _get ({ key, keyOptions, specOptions: { keyVaultName } }) {
+  async _get ({ key, specOptions: { keyVaultName } }) {
     const client = this._keyvaultClient({ keyVaultName })
     this._logger.info(`fetching secret ${key} from Azure KeyVault ${keyVaultName}`)
     const secret = await client.getSecret(key)
-    // Handle binary files, since the Azure client does not
-    if (keyOptions && keyOptions.isBinary) {
-      return Buffer.from(secret.value, 'base64')
-    }
     return secret.value
   }
 }

--- a/lib/backends/gcp-secrets-manager-backend.js
+++ b/lib/backends/gcp-secrets-manager-backend.js
@@ -44,13 +44,7 @@ class GCPSecretsManagerBackend extends KVBackend {
     const [version] = await this._client.accessSecretVersion({
       name: 'projects/' + projectId + '/secrets/' + key + '/versions/' + secretVersion
     })
-    const secret = version.payload.data.toString('utf8')
-    // Handle binary files - this is useful when you've stored a base64 encoded string
-    if (keyOptions && keyOptions.isBinary) {
-      return Buffer.from(secret, 'base64')
-    }
-
-    return secret
+    return version.payload.data.toString('utf8')
   }
 }
 

--- a/lib/backends/kv-backend.js
+++ b/lib/backends/kv-backend.js
@@ -20,6 +20,8 @@ class KVBackend extends AbstractBackend {
    * @param {string} data[].name - Kubernetes Secret property name.
    * @param {string} data[].property - If the backend secret is an
    *   object, this is the property name of the value to use.
+   * @param {string} data[].isBinary - If the backend secret shall be treated
+   *   as binary data represented by a base64-encoded string. Defaults to false.
    * @param {Object} specOptions - Options set on spec level.
    * @returns {Promise} Promise object representing secret property values.
    */
@@ -28,6 +30,7 @@ class KVBackend extends AbstractBackend {
       const { name, property = null, key, ...keyOptions } = dataItem
       const plainOrObjValue = await this._get({ key, keyOptions, specOptions })
       const shouldParseValue = 'property' in dataItem
+      const isBinary = 'isBinary' in dataItem && dataItem.isBinary === true
 
       let value = plainOrObjValue
       if (shouldParseValue) {
@@ -46,6 +49,16 @@ class KVBackend extends AbstractBackend {
         }
 
         value = parsedValue[property]
+      }
+
+      if (isBinary) {
+        // value in the backend is binary data which is already encoded in base64.
+        if (typeof value === 'string') {
+          // Skip this step if the value from the backend is not a string (e.g., AWS
+          // SecretsManager will already return a `Buffer` with base64 encoding if the
+          // secret contains `SecretBinary` instead of `SecretString`).
+          value = Buffer.from(value, 'base64')
+        }
       }
 
       return { [name]: value }

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -490,6 +490,7 @@ describe('kv-backend', () => {
       kvBackend._get.onCall(0).resolves(Buffer.from('YmluYXJ5Cg==', 'base64')) // base64 of binary as a Buffer
       kvBackend._get.onCall(1).resolves(Buffer.from('YmluYXJ5Cg==', 'base64')) // base64 of binary as a Buffer
       kvBackend._get.onCall(2).resolves('YmluYXJ5Cg==') // base64 of binary as String
+      kvBackend._get.onCall(3).resolves('test')
       // e.g. AWS Secrets Manager will return `SecretBinary` as a Buffer and `SecretString` as a String
 
       const manifestData = await kvBackend.getSecretManifestData({
@@ -508,6 +509,10 @@ describe('kv-backend', () => {
             // isBinary: false,
             // must be set to true to ensure base64-encoded string in the backend
             // is not encoded in base64 again
+          }, {
+            key: 'stringPropertyKey4',
+            name: 'stringPropertyName4',
+            isBinary: false // explicitly set false
           }]
         }
       })
@@ -515,7 +520,8 @@ describe('kv-backend', () => {
       expect(manifestData).deep.equals({
         binaryPropertyName1: 'YmluYXJ5Cg==', // base64 of binary (unchanged)
         binaryPropertyName2: 'YmluYXJ5Cg==', // base64 of binary (unchanged)
-        stringPropertyName3: 'WW1sdVlYSjVDZz09' // base64 of base64 of binary
+        stringPropertyName3: 'WW1sdVlYSjVDZz09', // base64 of base64 of binary
+        stringPropertyName4: 'dGVzdA==' // base64 of test
       })
     })
   })

--- a/lib/backends/kv-backend.test.js
+++ b/lib/backends/kv-backend.test.js
@@ -103,6 +103,42 @@ describe('kv-backend', () => {
       expect(secretPropertyValues).deep.equals([{ fakePropertyName1: 'fakePropertyValue1' }, { fakePropertyName2: 'fakePropertyValue2' }])
     })
 
+    it('handles binary values', async () => {
+      kvBackend._get.onCall(0).resolves('YmluYXJ5Cg==') // base64 of binary
+      kvBackend._get.onCall(1).resolves('stringPropertyValue1')
+      kvBackend._get.onCall(2).resolves('{"stringPropertyKey2": "stringPropertyValue2", "binaryPropertyKey2": "YmluYXJ5Cg=="}')
+      kvBackend._get.onCall(3).resolves('{"stringPropertyKey2": "stringPropertyValue2", "binaryPropertyKey2": "YmluYXJ5Cg=="}')
+
+      const secretPropertyValues = await kvBackend._fetchDataValues({
+        data: [{
+          key: 'binaryPropertyKey1',
+          name: 'binaryPropertyName1',
+          isBinary: true
+        }, {
+          key: 'stringPropertyKey1',
+          name: 'stringPropertyName1'
+          // isBinary: false
+        }, {
+          key: 'jsonProperties',
+          name: 'stringPropertyName2',
+          // isBinary: false,
+          property: 'stringPropertyKey2'
+        }, {
+          key: 'jsonProperties',
+          name: 'binaryPropertyName2',
+          isBinary: true,
+          property: 'binaryPropertyKey2'
+        }]
+      })
+
+      expect(secretPropertyValues).deep.equals(
+        [{ binaryPropertyName1: Buffer.from('YmluYXJ5Cg==', 'base64') }, // base64 of binary (unchanged)
+          { stringPropertyName1: 'stringPropertyValue1' },
+          { stringPropertyName2: 'stringPropertyValue2' },
+          { binaryPropertyName2: Buffer.from('YmluYXJ5Cg==', 'base64') } // base64 of binary (unchanged)
+        ])
+    })
+
     it('fetches secret property values using the specified role', async () => {
       kvBackend._get.onFirstCall().resolves('fakePropertyValue1')
       kvBackend._get.onSecondCall().resolves('fakePropertyValue2')
@@ -422,8 +458,11 @@ describe('kv-backend', () => {
   })
 
   describe('base64 encoding', () => {
-    it('handles json objects', async () => {
+    beforeEach(() => {
       kvBackend._get = sinon.stub()
+    })
+
+    it('handles json objects', async () => {
       kvBackend._get
         .resolves(JSON.stringify({
           textProperty: 'text',
@@ -444,6 +483,39 @@ describe('kv-backend', () => {
         textProperty: 'dGV4dA==', // base 64 value of text
         jsonStringProperty: 'eyAic29tZUtleSI6IHsgIm15VGV4dCI6ICJ0ZXh0IiB9IH0=', // base 64 value of: { "someKey": { "myText": "text" } }
         jsonProperty: 'eyJzb21lS2V5Ijp7Im15VGV4dCI6InRleHQifX0=' // base 64 value of: {"someKey":{"myText":"text"}}
+      })
+    })
+
+    it('handles different types of binary data returned by backends', async () => {
+      kvBackend._get.onCall(0).resolves(Buffer.from('YmluYXJ5Cg==', 'base64')) // base64 of binary as a Buffer
+      kvBackend._get.onCall(1).resolves(Buffer.from('YmluYXJ5Cg==', 'base64')) // base64 of binary as a Buffer
+      kvBackend._get.onCall(2).resolves('YmluYXJ5Cg==') // base64 of binary as String
+      // e.g. AWS Secrets Manager will return `SecretBinary` as a Buffer and `SecretString` as a String
+
+      const manifestData = await kvBackend.getSecretManifestData({
+        spec: {
+          data: [{
+            key: 'binaryPropertyKey1',
+            name: 'binaryPropertyName1',
+            isBinary: true
+          }, {
+            key: 'binaryPropertyKey2',
+            name: 'binaryPropertyName2'
+            // isBinary: false, but will have no impact if the backend returns a Buffer
+          }, {
+            key: 'stringPropertyKey3',
+            name: 'stringPropertyName3'
+            // isBinary: false,
+            // must be set to true to ensure base64-encoded string in the backend
+            // is not encoded in base64 again
+          }]
+        }
+      })
+
+      expect(manifestData).deep.equals({
+        binaryPropertyName1: 'YmluYXJ5Cg==', // base64 of binary (unchanged)
+        binaryPropertyName2: 'YmluYXJ5Cg==', // base64 of binary (unchanged)
+        stringPropertyName3: 'WW1sdVlYSjVDZz09' // base64 of base64 of binary
       })
     })
   })


### PR DESCRIPTION
- Add support for `isBinary` in `KVBackend` + tests
- Remove specific implementation of `isBinary` from Azure Key Vault & GCP Secrets Manager backends
- Update description for `isBinary` field in the CRD to remove Azure-specific details
- Update docs